### PR TITLE
[#3] Add Pagination Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,101 +1,233 @@
 var os = require('os');
+var Q = require('q');
 var rp = require('request-promise');
 var util = require('util');
 var version = require('./package.json').version;
 
+// Private Vars
+var options = {
+  method: 'GET',
+  uri: '',
+  json: true,
+  resolveWithFullResponse: true,
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': '',
+    'Accept': 'application/vnd.stattleship.com; version=1',
+    'User-Agent': util.format('Stattleship-Node/%s (%s)', version, platform)
+  },
+  qs: {}
+};
 var platform = util.format('%s-%s%s', os.arch(), os.platform(), os.release());
 
-module.exports = function(key) {
-  // Set the key
-  this.key = key;
+// Private Functions
+function callEndPoint(sport, league, endpoint, params, paginate, data, total) {
+  var deferred = Q.defer();
+  options.uri = util.format("https://www.stattleship.com/%s/%s/%s", sport, league, endpoint);
+  options.qs = params;
+  options.qs.page = options.qs.page || 1;
+  console.log(options.qs.page);
 
-  // Set the options
-  this.options = {
-    method: 'GET',
-    uri: '',
-    json: true,
-    resolveWithFullResponse: true,
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': util.format('Token token=%s', this.key),
-      'Accept': 'application/vnd.stattleship.com; version=1',
-      'User-Agent': util.format('Stattleship-Node/%s (%s)', version, platform)
-    },
-    qs: {}
-  };
+  rp(options).then(function(response) {
+    total = response.headers.total;
+    console.log(total);
+    data = data.concat(response.body[endpoint]);
+    console.log(Object.keys(data).length);
+    options.qs.page++;
 
-  this.callEndPoint = function(sport, league, endpoint, params) {
-    this.options.uri = util.format("https://www.stattleship.com/%s/%s/%s", sport, league, endpoint);
-    this.options.qs = params;
+    // Page is 0 if use did not specify specific page, if they did no need to recurse
+    if(paginate && Object.keys(data).length < total) {
+      callEndPoint(sport, league, endpoint, params, paginate, data, total).then(function(data) {
+        deferred.resolve(data);
+      });
+    } else {
+      deferred.resolve(data);
+    }
+  });
 
-    return rp(this.options).then(function(response) {
-      return response.body[endpoint];
-    }).catch(function(err) {
-      throw (err);
-    });
-  };
+  return deferred.promise;
+}
 
-  this.feats = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "feats", params);
-  };
+// Object
+function Stattleship(token) {
+  options.headers.Authorization = util.format('Token token=%s', token);
+}
 
-  this.game_logs = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "game_logs", params);
-  };
+// Public Functions
+Stattleship.prototype.feats = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
 
-  this.games = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "games", params);
-  };
-
-  this.injuries = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "injuries", params);
-  };
-
-  this.penalties = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "penalties", params);
-  };
-
-  this.players = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "players", params);
-  };
-
-  this.rankings = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "rankings", params);
-  };
-
-  this.rosters = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "rosters", params);
-  };
-
-  this.scoring_plays = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "scoring_plays", params);
-  };
-
-  this.stat_leaders = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "stat_leaders", params);
-  };
-
-  this.stats = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "stats", params);
-  };
-
-  this.team_game_logs = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "team_game_logs", params);
-  };
-
-  this.team_outcome_streaks = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "team_outcome_streaks", params);
-  };
-
-  this.teams = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "teams", params);
-  };
-
-  this.top_stats = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "top_stats", params);
-  };
-
-  this.total_stats = function(sport, league, params) {
-    return this.callEndPoint(sport, league, "total_stats", params);
-  };
+  return callEndPoint(sport, league, "feats", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
 };
+
+Stattleship.prototype.game_logs = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "game_logs", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+Stattleship.prototype.games = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "games", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+Stattleship.prototype.injuries = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "injuries", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+Stattleship.prototype.penalties = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "penalties", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+Stattleship.prototype.players = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "players", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+Stattleship.prototype.rankings = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "rankings", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+Stattleship.prototype.rosters = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "rosters", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+Stattleship.prototype.scoring_plays = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "scoring_plays", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+Stattleship.prototype.stat_leaders = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "stat_leaders", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+Stattleship.prototype.stats = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "stats", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+Stattleship.prototype.team_game_logs = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "team_game_logs", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+Stattleship.prototype.team_outcome_streaks = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "team_outcome_streaks", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+Stattleship.prototype.teams = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "teams", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+Stattleship.prototype.top_stats = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "top_stats", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+Stattleship.prototype.total_stats = function(sport, league, params) {
+  var data = [];
+  var total = 0;
+  var paginate = (params.page === undefined);
+
+  return callEndPoint(sport, league, "total_stats", params, paginate, data, total)
+    .then(function(data) {
+      return data;
+  });
+};
+
+module.exports = Stattleship;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/jlcarmic/node-stattleship#readme",
   "dependencies": {
+    "q": "^1.4.1",
     "request-promise": "^3.0.0",
     "util": "^0.10.3"
   },

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -17,7 +17,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/feats', sport, league);
+      var endpoint = util.format('/%s/%s/feats?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { feats: [ { level: "rare" } ] });
@@ -41,7 +41,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/game_logs', sport, league);
+      var endpoint = util.format('/%s/%s/game_logs?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { game_logs: [ { home_team_outcome: "win" } ] });
@@ -65,7 +65,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/games', sport, league);
+      var endpoint = util.format('/%s/%s/games?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { games: [ { label: "X-Men vs Avengers" } ] });
@@ -89,7 +89,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/injuries', sport, league);
+      var endpoint = util.format('/%s/%s/injuries?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { injuries: [ { location_name: "Skull" } ] });
@@ -113,7 +113,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/penalties', sport, league);
+      var endpoint = util.format('/%s/%s/penalties?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { penalties: [ { name: "Inappropriate Touching" } ] });
@@ -137,7 +137,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/players', sport, league);
+      var endpoint = util.format('/%s/%s/players?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { players: [ { name: "Tony Stark" } ] });
@@ -161,7 +161,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/rankings', sport, league);
+      var endpoint = util.format('/%s/%s/rankings?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { rankings: [ { place: 42 } ] });
@@ -185,7 +185,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/rosters', sport, league);
+      var endpoint = util.format('/%s/%s/rosters?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { rosters: [ { team_id: 'kjh34kj23hkjh' } ] });
@@ -209,7 +209,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/scoring_plays', sport, league);
+      var endpoint = util.format('/%s/%s/scoring_plays?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { scoring_plays: [ { name: 'Touchdown' } ] });
@@ -233,7 +233,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/stat_leaders', sport, league);
+      var endpoint = util.format('/%s/%s/stat_leaders?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { stat_leaders: [ { stat_name: 'home_runs' } ] });
@@ -257,7 +257,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/stats', sport, league);
+      var endpoint = util.format('/%s/%s/stats?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { stats: [ { stat: 'passes_touchdowns' } ] });
@@ -281,7 +281,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/team_game_logs', sport, league);
+      var endpoint = util.format('/%s/%s/team_game_logs?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { team_game_logs: [ { home_team_outcome: 'win' } ] });
@@ -305,7 +305,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/team_outcome_streaks', sport, league);
+      var endpoint = util.format('/%s/%s/team_outcome_streaks?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { team_outcome_streaks: [ { streak_length: 42 } ] });
@@ -329,7 +329,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/teams', sport, league);
+      var endpoint = util.format('/%s/%s/teams?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { teams: [ { nickname: 'Avengers' } ] });
@@ -353,7 +353,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/top_stats', sport, league);
+      var endpoint = util.format('/%s/%s/top_stats?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { top_stats: [ { stat_name: 'hits' } ] });
@@ -377,7 +377,7 @@ describe("stattleship", function() {
       var sport = 'baseball';
       var league = 'mlb';
 
-      var endpoint = util.format('/%s/%s/total_stats', sport, league);
+      var endpoint = util.format('/%s/%s/total_stats?page=1', sport, league);
       nock('https://www.stattleship.com')
         .get(endpoint)
         .reply(200, { total_stats: [ { stat: 'passes_touchdowns' } ] });


### PR DESCRIPTION
- Refactored Stattleship class: DRY'd up functions and added proper class structure
- Added recursion to API calls to handle pagination
- Added Q library for use in recursion
- Updated test endpoints to support pagination changes

Closes #3
Current design does not return sideloaded data, will revisit in future issue.

https://github.com/jlcarmic/node-stattleship/issues/3
